### PR TITLE
Facelift the guide

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,8 +3,8 @@
 :idseparator: -
 :sectanchors:
 :sectlinks:
-:toc: left
-:toclevels: 2
+:toc: preamble
+:toclevels: 1
 ifndef::backend-pdf[]
 :toc-title: pass:[<h2>Table of Contents</h2>]
 endif::[]

--- a/README.adoc
+++ b/README.adoc
@@ -18,6 +18,9 @@ Sidekiq may be used without Active Job, but the latter adds transparency and a u
 
 This style guide didn't appear out of thin air - it is based on the professional experience of the editors, official documentation, and suggestions from members of the Ruby community.
 
+Those guidelines help to avoid numerous pitfalls.
+Depending on the usage of background jobs, some guidelines might apply, and some not.
+
 ifdef::env-github[]
 You can generate a PDF copy of this guide using https://asciidoctor.org/docs/asciidoctor-pdf/[AsciiDoctor PDF], and an HTML copy https://asciidoctor.org/docs/convert-documents/#converting-a-document-to-html[with] https://asciidoctor.org/#installation[AsciiDoctor] using the following commands:
 
@@ -906,7 +909,6 @@ end
 
 This guide came to life as an internal https://www.toptal.com[company] list of the best practices of working with ActiveJob and Sidekiq (written by https://github.com/pirj[Phil Pirozhkov]).
 It is compiled from remarks collected from numerous code reviews conducted by its authors and outlines the best practices of working with background jobs in Ruby.
-Not only will those guidelines save an incredible amount of developer time, but it will also save from pitfalls.
 
 == Contributing
 

--- a/README.adoc
+++ b/README.adoc
@@ -907,8 +907,9 @@ end
 
 == History
 
-This guide came to life as an internal https://www.toptal.com[company] list of the best practices of working with ActiveJob and Sidekiq (written by https://github.com/pirj[Phil Pirozhkov]).
-It is compiled from remarks collected from numerous code reviews conducted by its authors and outlines the best practices of working with background jobs in Ruby.
+This guide came to life as an internal company list of the best practices of working with ActiveJob and Sidekiq.
+It is compiled from remarks collected from numerous code reviews, and during the migration from another background job processing tool to Sidekiq.
+Initially created by https://github.com/pirj[Phil Pirozhkov]) with the help of colleagues, and sponsored by https://www.toptal.com[Toptal].
 
 == Contributing
 


### PR DESCRIPTION
The guide has been open-sourced. Before doing any announcements, a couple of minor but important changes are needed:

- give Toptal proper credit for sponsoring all initial work on the guide:
   - gathering good and bad practices from existing code
   - researching and getting to the bottom of problems of improper use
   - extracting good patterns from the migration to Sidekiq
   - colleague's work on reviewing and proofreading the guide
 - fix TOC appearance on Github
 - make it clear that most but not all of the guidelines apply to everyone