### PR TITLE
Change class name reference to described_class in tests

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -874,7 +874,7 @@ end
 # good
 RSpec.describe SomeJob do
   it 'updates user status' do
-    expect { SomeJob.perform_now(user) }.to change { user.status }.to(:updated) }
+    expect { described_class.perform_now(user) }.to change { user.status }.to(:updated) }
   end
 end
 ----


### PR DESCRIPTION
Change explicit class name reference in #testing to use `described_class`